### PR TITLE
[QA NEEDED] Fixed nginx proxy issues

### DIFF
--- a/al-nginx/Dockerfile
+++ b/al-nginx/Dockerfile
@@ -1,5 +1,0 @@
-FROM docker.pkg.github.com/opendata-mvcr/react-nginx/react-nginx:latest
-# Run config check script on the container startup
-COPY config_check.sh /docker-entrypoint.d/
-# Provide improved nginx configuration
-COPY nginx.conf /etc/nginx/

--- a/al-nginx/error.html
+++ b/al-nginx/error.html
@@ -1,0 +1,38 @@
+<!-- Assembly Line Nginx reverse proxy-->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>
+      <!--# echo var="status" default="" -->
+      | Assembly Line
+    </title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!--# if expr="$status = 502" -->
+      <meta http-equiv="refresh" content="2">
+    <!--# endif -->
+  </head>
+  <style type="text/css">
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      color: #fff;
+      height: 100vh;
+      margin: 0;
+      background: #263238 linear-gradient(5deg, #057fa5 0%, #263238 100%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+  </style>
+<body>
+  <!--# if expr="$status = 502" -->
+    <h1>Právě probíhá aktualizace aplikace </h1>
+    <p>Za několik sekund budete přesměrováni na novou verzi.</p>
+    <p>Pokud tuto zprávu vidíte déle než minutu, něco se pokazilo.</p>
+  <!--# else -->
+    <h1>Omlouváme se, něco se pokazilo.</h1>
+    <p><!--# echo var="status" default="" --></p>
+  <!--# endif -->
+</body>
+</html>

--- a/al-nginx/nginx.conf
+++ b/al-nginx/nginx.conf
@@ -42,92 +42,38 @@ http {
             root /usr/share/nginx/html;
         }
 
-        location = /modelujeme/sluzby/auth-server {
-          return 302 /modelujeme/sluzby/auth-server/;
-        }
-
         location /modelujeme/sluzby/auth-server/ {
-            proxy_pass http://al-auth-server:8080;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_pass http://al-auth-server:8080; # no trailing slash to preserve matched prefix
+            # Keycloak does not work without the settings below for some reason
             proxy_buffer_size   128k;
             proxy_buffers       4 256k;
             proxy_busy_buffers_size 256k;
         }
 
-        location = /modelujeme/sluzby/db-server {
-            return 302 /modelujeme/sluzby/db-server/;
-        }
-
         location /modelujeme/sluzby/db-server/ {
-            rewrite ^/modelujeme/sluzby/db-server/(.*) /$1 break;
-            proxy_pass http://al-db-server:7200;
-            proxy_redirect http://al-db-server:7200/ /modelujeme/sluzby/db-server/;
-            proxy_set_header X-Forwarded-Host $host;
-        }
-
-        location = /modelujeme/sluzby/sgov-server {
-          return 302 /modelujeme/sluzby/sgov-server/;
+            proxy_pass http://al-db-server:7200/; # keep the trailing slash to cut off matched prefix
         }
 
         location /modelujeme/sluzby/sgov-server/ {
-            proxy_pass http://al-sgov-server:8080/modelujeme/sluzby/sgov-server/;
-            proxy_set_header X-Forwarded-Host $host;
-        }
-
-        location = /modelujeme/sluzby/termit-server {
-          return 302 /modelujeme/sluzby/termit-server/;
+            proxy_pass http://al-sgov-server:8080; # # no trailing slash to preserve matched prefix
+            #proxy_set_header X-Forwarded-Host $host;
         }
 
         location /modelujeme/sluzby/termit-server/ {
-            proxy_pass http://al-termit-server:8080/modelujeme/sluzby/termit-server/;
-            proxy_set_header X-Forwarded-Host $host;
-        }
-
-        location = /modelujeme/v-nástroji/ontographer {
-          return 302 /modelujeme/v-nástroji/ontographer/;
+            proxy_pass http://al-termit-server:8080; # # no trailing slash to preserve matched prefix
+            #proxy_set_header X-Forwarded-Host $host;
         }
 
         location /modelujeme/v-nástroji/ontographer/ {
-            rewrite ^/modelujeme/v-nástroji/ontographer/(.*) /$1 break;
-            proxy_pass http://al-ontographer/;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection 'upgrade';
-            proxy_set_header Host $host;
-            proxy_cache_bypass $http_upgrade;
-            #expires 30d;
-            break;
-        }
-
-        location = /modelujeme/v-nástroji/termit {
-          return 302 /modelujeme/v-nástroji/termit/;
+            proxy_pass http://al-ontographer/; # keep the trailing slash to cut off matched prefix
         }
 
         location /modelujeme/v-nástroji/termit/ {
-            rewrite ^/modelujeme/v-nástroji/termit/(.*) /$1 break;
-            proxy_pass http://al-termit/;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection 'upgrade';
-            proxy_set_header Host $host;
-            proxy_cache_bypass $http_upgrade;
-            break;
-        }
-
-        location = /modelujeme {
-            return 302 /modelujeme/;
+            proxy_pass http://al-termit/; # keep the trailing slash to cut off matched prefix
         }
 
         location /modelujeme/ {
-            rewrite ^/modelujeme/(.*) /$1 break;
-            proxy_pass http://al-mission-control/;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection 'upgrade';
-            proxy_set_header Host $host;
-            proxy_cache_bypass $http_upgrade;
-            #expires 30d;
-            break;
+            proxy_pass http://al-mission-control/; # keep the trailing slash to cut off matched prefix
         }
 
         location /health-check {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,13 @@
 version: "3.9"
 services:
   al-nginx:
-    build:
-      context: al-nginx
-    image: al-nginx
+    image: nginx:latest
+    container_name: al-nginx
+    volumes:
+      - ./al-nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./al-nginx/error.html:/usr/share/nginx/html/error.html
     ports:
-      - 80:80
-      - 443:443
+      - 1234:80
     restart: always
     depends_on:
       - al-mission-control

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ version: "3.9"
 services:
   al-nginx:
     image: nginx:latest
-    container_name: al-nginx
     volumes:
       - ./al-nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./al-nginx/error.html:/usr/share/nginx/html/error.html

--- a/gen_env.sh
+++ b/gen_env.sh
@@ -14,7 +14,7 @@ case $ENV in
 
   local)
     export CONTEXT=development
-    export URL=http://localhost/modelujeme
+    export URL=https://xn--slovnk-7va.dev/modelujeme
     FILE=.env.local
     ;;
 

--- a/master-nginx-poc/nginx.conf
+++ b/master-nginx-poc/nginx.conf
@@ -1,0 +1,69 @@
+
+#user  nobody;
+worker_processes  1;
+
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+#pid        logs/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    server {
+        listen       80 default_server;
+        server_name  _;
+
+        return 301 https://$host$request_uri;
+
+    # HTTPS server
+    
+    server {
+        listen       443 ssl;
+        server_name  _;
+    
+        ssl_certificate      "C:/ssl/server.crt"; # replace me
+        ssl_certificate_key  "C:/ssl/server.key"; # replace me
+
+        location / {
+            root   html;
+            index  index.html index.htm;
+        }
+
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   html;
+        }
+
+        location /modelujeme/ {
+            proxy_pass http://localhost:1234; # no trailing slash to preserve /modelujeme/ prefix because of Keycloak
+
+            proxy_http_version  1.1;
+            proxy_cache_bypass  $http_upgrade;
+
+            proxy_set_header Upgrade           $http_upgrade;
+            proxy_set_header Connection        "upgrade";
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host  $host;
+            proxy_set_header X-Forwarded-Port  $server_port;
+        }
+    }
+
+}


### PR DESCRIPTION
I have refactored and possibly fixed all the proxy / SSL issues that we have with the reverse-proxy hierarchy.

How I did it:
1. I have set up a detached master nginx proxy (to mimic the one on prod server) that dispatches requests from `https://slovník.dev/modelujeme` to `http://localhost:1234/modelujeme`. This proxy contains almost all of the proxy headers magic. In order to do this I have set up a local SSL certificate containing `slovník.dev` domain.
2. The Assembly Line runs on `http://localhost:1234`. I needed to move it from the 80 port so that I can use the master proxy above.
3. I have refactored all the proxy rules and made them easy to understand. I have also replaced the custom nginx Docker image with the official one so that a rebuild of the nginx image is no longer needed when a configuration changed - simple restart of the container is enough.

Proxying variations: when it comes to proxying requests within AL, there are two strategies being used using the nginx `proxy_pass` command. The first one includes URI which means that the location prefix is stripped, the second one passes the whole URI so that the path is unchanged one layer deeped under the proxy. The only reason for this is Keycloak - it would require some non-trivial extra configuration to make it work. My original idea was to remove the "modelujeme" prefix from the AL configuration altogether, which is possible, but we'd need to build a custom Keycloak image with some configuration magic.

What is the biggest benefit, besides that the configuration finally makes sense: **it is possible to use the deployed apps from localhost without using HTTPS**, which was the most painful issue that we had.