### PR TITLE
Fix reference of downloaded graphdb file in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Tento repozitář obsahuje sadu Docker instrukcí pro nasazení Výrobní linky.
 
 Postup:
 
-0. Stáhni [GraphDB Free](https://graphdb.ontotext.com) do složky `graphdb`, např. `graphdb-free-9.6.0-dist.zip`.
+0. Stáhni [GraphDB Free](https://graphdb.ontotext.com) do složky `al-db-server`, např. `graphdb-free-9.6.0-dist.zip`.
 
 1. Vygeneruj soubor s proměnnými pomocí utility `gen_env.sh`. Utilita vyžaduje parametr s hodnotou `local`, `development` nebo `production`. V závislosti na parametru bude vygenerován příslušný `.env.*` soubor. Konfigurace komponent bude vygenerována z šablony `components.yml` a zakódována pomocí base64 do jednoduchého řetězce. Příklad:
 


### PR DESCRIPTION
Fixes `docker-compose up` failing during build of `al-db-server`. The error was "graphdb-free-9.6.0-dist.zip not found".

Relevant part in `docker-compose.yml` is:
```
  al-db-server:
    build:
      context: al-db-server
      args:
        GRAPHDB_ZIP: graphdb-free-9.10.1-dist.zip
    image: al-graphdb
```
