### PR TITLE
Fix url for local development

### DIFF
--- a/gen_env.sh
+++ b/gen_env.sh
@@ -14,7 +14,7 @@ case $ENV in
 
   local)
     export CONTEXT=development
-    export URL=https://xn--slovnk-7va.dev/modelujeme
+    export URL=http://localhost:1234/modelujeme
     FILE=.env.local
     ;;
 


### PR DESCRIPTION
I assumed, the following holds for  .env.*:
.env.local -- targets to my local deployment (on my computer)
.env.development -- targets to OHA servers (remote w.r.t. my computer)
.env.production -- targets to OHA servers

If my assumptions hold, that it makes sense to fix `get_env.sh` script as done.