### PR TITLE
Disables TermIt cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,7 @@ services:
       KEYCLOAK_REALMKEY: ${KEYCLOAK_REALMKEY}
       KEYCLOAK_CREDENTIALS_SECRET: ${TERMIT_SERVER_KEYCLOAK_CREDENTIALS_SECRET}
       KEYCLOAK_PUBLIC_CLIENT: "false"
+      SPRING_CACHE_TYPE: "none"
     depends_on:
       - al-db-server
       - al-auth-server


### PR DESCRIPTION
This is needed to prevent pre-caching a set of vocabularies for the first opened workspace and displaying them for all other.