### PR TITLE
Fix SSP deploy fail due to timeouts on db-server

### DIFF
--- a/al-nginx/nginx.conf
+++ b/al-nginx/nginx.conf
@@ -52,6 +52,11 @@ http {
 
         location /modelujeme/sluzby/db-server/ {
             proxy_pass http://al-db-server:7200/; # keep the trailing slash to cut off matched prefix
+
+            proxy_connect_timeout 500;
+            proxy_send_timeout 500;
+            proxy_read_timeout 500;
+            send_timeout 500;
         }
 
         location /modelujeme/sluzby/sgov-server/ {


### PR DESCRIPTION
SSP deploy should be fixed:
- I modified timeouts on proxy server (not included in this pull request)
- I modified timeouts within al-nginx service (this pull request)